### PR TITLE
Wrap data in a "messages" array to align with scc-broker-client

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,7 +74,9 @@ module.exports.attach = function (broker, options) {
       } else {
         data = message.slice(2);
       }
-      broker.publish(channel, data);
+      broker.publish(channel, {
+        messages: [data]
+      });
     }
   });
 };


### PR DESCRIPTION
Messages are not being published from redis to socket cluster when running in SCC mode.

Example...
https://github.com/SocketCluster/scc-broker-client/blob/master/index.js#L135 